### PR TITLE
Add admin dashboard and ad management

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,54 @@
+<?php
+require_once '../includes/functions.php';
+
+// Handle login
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['username'], $_POST['password'])) {
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE username = ? AND password = ? AND is_admin = 1 LIMIT 1');
+    $stmt->execute([$_POST['username'], $_POST['password']]);
+    $admin = $stmt->fetch();
+    if ($admin) {
+        $_SESSION['admin_logged_in'] = true;
+    } else {
+        $error = 'Invalid credentials';
+    }
+}
+
+if (!is_admin_logged_in()) {
+    ?>
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Admin Login</title>
+    </head>
+    <body>
+        <h2>Admin Login</h2>
+        <?php if (isset($error)) echo '<p style="color:red">'.htmlspecialchars($error).'</p>'; ?>
+        <form method="post">
+            <label>Username: <input type="text" name="username"></label><br>
+            <label>Password: <input type="password" name="password"></label><br>
+            <button type="submit">Login</button>
+        </form>
+    </body>
+    </html>
+    <?php
+    exit;
+}
+
+// Logged in - display dashboard stats
+$adsCount = $pdo->query('SELECT COUNT(*) FROM ads')->fetchColumn();
+$usersCount = $pdo->query('SELECT COUNT(*) FROM users')->fetchColumn();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+</head>
+<body>
+    <h1>Dashboard</h1>
+    <p>Total Ads: <?php echo $adsCount; ?></p>
+    <p>Total Users: <?php echo $usersCount; ?></p>
+    <p><a href="manage_ads.php">Manage Ads</a></p>
+</body>
+</html>

--- a/admin/manage_ads.php
+++ b/admin/manage_ads.php
@@ -1,0 +1,72 @@
+<?php
+require_once '../includes/functions.php';
+require_admin_login();
+
+// Approve ad
+if (isset($_GET['approve'])) {
+    $stmt = $pdo->prepare('UPDATE ads SET approved = 1 WHERE id = ?');
+    $stmt->execute([$_GET['approve']]);
+    header('Location: manage_ads.php');
+    exit;
+}
+
+// Delete ad
+if (isset($_GET['delete'])) {
+    $stmt = $pdo->prepare('DELETE FROM ads WHERE id = ?');
+    $stmt->execute([$_GET['delete']]);
+    header('Location: manage_ads.php');
+    exit;
+}
+
+// Edit ad
+if (isset($_POST['edit_id'])) {
+    $stmt = $pdo->prepare('UPDATE ads SET title = ?, description = ? WHERE id = ?');
+    $stmt->execute([$_POST['title'], $_POST['description'], $_POST['edit_id']]);
+    header('Location: manage_ads.php');
+    exit;
+}
+
+$ads = $pdo->query('SELECT * FROM ads ORDER BY id DESC')->fetchAll();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Ads</title>
+</head>
+<body>
+    <h1>Manage Ads</h1>
+    <p><a href="dashboard.php">Back to Dashboard</a></p>
+    <table border="1" cellpadding="5">
+        <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>Description</th>
+            <th>Approved</th>
+            <th>Actions</th>
+        </tr>
+        <?php foreach ($ads as $ad): ?>
+        <tr>
+            <td><?php echo $ad['id']; ?></td>
+            <td>
+                <form method="post" style="display:inline;">
+                    <input type="hidden" name="edit_id" value="<?php echo $ad['id']; ?>">
+                    <input type="text" name="title" value="<?php echo htmlspecialchars($ad['title']); ?>">
+            </td>
+            <td>
+                    <input type="text" name="description" value="<?php echo htmlspecialchars($ad['description']); ?>">
+            </td>
+            <td><?php echo $ad['approved'] ? 'Yes' : 'No'; ?></td>
+            <td>
+                    <button type="submit">Save</button>
+                </form>
+                <?php if (!$ad['approved']): ?>
+                    <a href="?approve=<?php echo $ad['id']; ?>">Approve</a>
+                <?php endif; ?>
+                <a href="?delete=<?php echo $ad['id']; ?>" onclick="return confirm('Delete this ad?');">Delete</a>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
+</body>
+</html>

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,19 @@
+<?php
+$host = 'localhost';
+$db   = 'tager';
+$user = 'root';
+$pass = '';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    exit('Database connection failed: ' . $e->getMessage());
+}
+?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+function is_admin_logged_in() {
+    return isset($_SESSION['admin_logged_in']) && $_SESSION['admin_logged_in'] === true;
+}
+
+function require_admin_login() {
+    if (!is_admin_logged_in()) {
+        header('Location: dashboard.php');
+        exit;
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- connect to MySQL using PDO
- provide helper functions for admin session handling
- build an admin dashboard with login and basic stats
- add an ad management page for approving, editing and deleting ads

## Testing
- `php -l includes/db.php`
- `php -l includes/functions.php`
- `php -l admin/dashboard.php`
- `php -l admin/manage_ads.php`


------
https://chatgpt.com/codex/tasks/task_e_6889ad0f0024832bafafadc7fafe8432