### PR TITLE
Implement basic ads platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/uploads/

--- a/ad_details.php
+++ b/ad_details.php
@@ -1,0 +1,32 @@
+<?php
+require_once 'includes/functions.php';
+$id = intval($_GET['id'] ?? 0);
+$stmt = $mysqli->prepare("SELECT a.*, u.phone, c.name AS city FROM ads a JOIN users u ON a.user_id=u.id JOIN cities c ON a.city_id=c.id WHERE a.id=? LIMIT 1");
+$stmt->bind_param('i',$id);
+$stmt->execute();
+$ad = $stmt->get_result()->fetch_assoc();
+$images = $mysqli->query("SELECT image_path FROM ad_images WHERE ad_id={$id}");
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header><?=htmlspecialchars($ad['title'])?></header>
+<div class="card">
+<?php while($img = $images->fetch_assoc()): ?>
+<img src="uploads/<?=htmlspecialchars($img['image_path'])?>" alt="">
+<?php endwhile; ?>
+<p><?=nl2br(htmlspecialchars($ad['description']))?></p>
+<p>السعر: <?=htmlspecialchars($ad['price'])?></p>
+<p>المدينة: <?=htmlspecialchars($ad['city'])?></p>
+<p>تاريخ: <?=formatDate($ad['created_at'])?></p>
+<p>الهاتف: <?=htmlspecialchars($ad['phone'])?></p>
+<form method="post" action="report.php?id=<?=$ad['id']?>">
+<button type="submit">إبلاغ</button>
+</form>
+</div>
+</body>
+</html>

--- a/add_ad.php
+++ b/add_ad.php
@@ -1,0 +1,58 @@
+<?php
+require_once 'includes/functions.php';
+if(!isLoggedIn()) { header('Location: login.php'); exit; }
+
+$cities = $mysqli->query("SELECT id,name FROM cities");
+$cats = $mysqli->query("SELECT id,name FROM categories");
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $title = sanitizeInput($_POST['title']);
+    $desc  = sanitizeInput($_POST['description']);
+    $price = floatval($_POST['price']);
+    $city  = intval($_POST['city']);
+    $cat   = intval($_POST['category']);
+    $stmt = $mysqli->prepare("INSERT INTO ads (user_id,title,description,price,city_id,category_id,created_at) VALUES (?,?,?,?,?,?,NOW())");
+    $stmt->bind_param('issdii', $_SESSION['user_id'], $title, $desc, $price, $city, $cat);
+    $stmt->execute();
+    $ad_id = $stmt->insert_id;
+    if(!is_dir('uploads')) mkdir('uploads');
+    foreach($_FILES['images']['tmp_name'] as $key=>$tmp){
+        if($tmp){
+            $name = time().'_'.$key.'.jpg';
+            move_uploaded_file($tmp, 'uploads/'.$name);
+            $mysqli->query("INSERT INTO ad_images (ad_id,image_path) VALUES ($ad_id,'$name')");
+        }
+    }
+    header('Location: ad_details.php?id='.$ad_id);
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="css/style.css">
+<script src="js/scripts.js"></script>
+</head>
+<body>
+<header>إضافة إعلان</header>
+<form method="post" enctype="multipart/form-data">
+<input type="text" name="title" placeholder="العنوان" required>
+<textarea name="description" placeholder="الوصف" required></textarea>
+<input type="number" name="price" placeholder="السعر" required>
+<select name="city" required>
+<?php while($c=$cities->fetch_assoc()): ?>
+<option value="<?=$c['id']?>"><?=$c['name']?></option>
+<?php endwhile; ?>
+</select>
+<select name="category" required>
+<?php while($c=$cats->fetch_assoc()): ?>
+<option value="<?=$c['id']?>"><?=$c['name']?></option>
+<?php endwhile; ?>
+</select>
+<input type="file" name="images[]" multiple onchange="previewImages(this, document.getElementById('preview'))">
+<div id="preview"></div>
+<button type="submit">حفظ</button>
+</form>
+</body>
+</html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,25 @@
+<?php
+require_once '../includes/functions.php';
+if(!isAdmin()){ header('Location: ../login.php'); exit; }
+$totalUsers = $mysqli->query("SELECT COUNT(*) FROM users")->fetch_row()[0];
+$totalAds = $mysqli->query("SELECT COUNT(*) FROM ads")->fetch_row()[0];
+$totalReports = $mysqli->query("SELECT COUNT(*) FROM reports")->fetch_row()[0];
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+<header>لوحة التحكم</header>
+<p>المستخدمون: <?=$totalUsers?></p>
+<p>الإعلانات: <?=$totalAds?></p>
+<p>البلاغات: <?=$totalReports?></p>
+<ul>
+<li><a href="manage_ads.php">إدارة الإعلانات</a></li>
+<li><a href="manage_users.php">إدارة المستخدمين</a></li>
+<li><a href="manage_reports.php">إدارة البلاغات</a></li>
+</ul>
+</body>
+</html>

--- a/admin/manage_ads.php
+++ b/admin/manage_ads.php
@@ -1,0 +1,31 @@
+<?php
+require_once '../includes/functions.php';
+if(!isAdmin()){ header('Location: ../login.php'); exit; }
+$ads = $mysqli->query("SELECT a.*, u.name AS user, c.name AS category FROM ads a JOIN users u ON a.user_id=u.id JOIN categories c ON a.category_id=c.id ORDER BY a.created_at DESC");
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../css/style.css">
+<script src="../js/scripts.js"></script>
+</head>
+<body>
+<header>إدارة الإعلانات</header>
+<table border="1" width="100%">
+<tr><th>العنوان</th><th>المستخدم</th><th>القسم</th><th>إجراءات</th></tr>
+<?php while($ad=$ads->fetch_assoc()): ?>
+<tr>
+<td><?=htmlspecialchars($ad['title'])?></td>
+<td><?=htmlspecialchars($ad['user'])?></td>
+<td><?=htmlspecialchars($ad['category'])?></td>
+<td>
+<a href="../ad_details.php?id=<?=$ad['id']?>">عرض</a> |
+<a href="delete_ad.php?id=<?=$ad['id']?>" onclick="return confirmDelete();">حذف</a> |
+<a href="feature_ad.php?id=<?=$ad['id']?>">تمييز</a>
+</td>
+</tr>
+<?php endwhile; ?>
+</table>
+</body>
+</html>

--- a/ads.php
+++ b/ads.php
@@ -1,0 +1,32 @@
+<?php
+require_once 'includes/functions.php';
+$where = [];
+if(isset($_GET['category'])) $where[] = 'a.category_id='.(int)$_GET['category'];
+if(isset($_GET['city'])) $where[] = 'a.city_id='.(int)$_GET['city'];
+if(isset($_GET['min_price'])) $where[] = 'a.price>='.(float)$_GET['min_price'];
+if(isset($_GET['max_price'])) $where[] = 'a.price<='.(float)$_GET['max_price'];
+$whereSql = $where ? 'WHERE '.implode(' AND ',$where) : '';
+$sql = "SELECT a.*, c.name AS city, (SELECT image_path FROM ad_images WHERE ad_id=a.id LIMIT 1) AS main_image FROM ads a JOIN cities c ON a.city_id=c.id $whereSql ORDER BY a.created_at DESC";
+$result = $mysqli->query($sql);
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>البحث في الإعلانات</header>
+<div class="cards">
+<?php while($ad=$result->fetch_assoc()): ?>
+<div class="card">
+<img src="uploads/<?=htmlspecialchars($ad['main_image'])?>" alt="">
+<h3><?=htmlspecialchars($ad['title'])?></h3>
+<p>السعر: <?=htmlspecialchars($ad['price'])?></p>
+<p>المدينة: <?=htmlspecialchars($ad['city'])?></p>
+<a href="ad_details.php?id=<?=$ad['id']?>">تفاصيل</a>
+</div>
+<?php endwhile; ?>
+</div>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,7 @@
+body { direction: rtl; font-family: Arial, sans-serif; background:#f0f0f0; }
+header { background:#0d6efd; color:#fff; padding:10px; text-align:center; font-weight:bold; }
+.card { background:#fff; border:1px solid #ccc; padding:10px; margin:10px; border-radius:4px; }
+.cards { display:flex; flex-wrap:wrap; justify-content:center; }
+.card img { max-width:100%; height:150px; object-fit:cover; }
+form { max-width:600px; margin:20px auto; background:#fff; padding:20px; border-radius:4px; }
+@media(max-width:600px){ .cards {flex-direction:column;} }

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,12 @@
+<?php
+$host = 'localhost';
+$db   = 'tager_db';
+$user = 'root';
+$pass = '';
+
+$mysqli = new mysqli($host, $user, $pass, $db);
+if ($mysqli->connect_error) {
+    die('Database connection error: ' . $mysqli->connect_error);
+}
+$mysqli->set_charset('utf8mb4');
+?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,21 @@
+<?php
+session_start();
+require_once __DIR__ . '/db.php';
+
+function isLoggedIn() {
+    return isset($_SESSION['user_id']);
+}
+
+function isAdmin() {
+    return isset($_SESSION['is_admin']) && $_SESSION['is_admin'] == 1;
+}
+
+function sanitizeInput($input) {
+    global $mysqli;
+    return htmlspecialchars(trim($mysqli->real_escape_string($input)), ENT_QUOTES, 'UTF-8');
+}
+
+function formatDate($timestamp) {
+    return date('Y-m-d H:i', strtotime($timestamp));
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,27 @@
+<?php
+require_once 'includes/functions.php';
+$query = "SELECT a.*, c.name AS city, (SELECT image_path FROM ad_images WHERE ad_id=a.id LIMIT 1) AS main_image FROM ads a JOIN cities c ON a.city_id=c.id ORDER BY a.created_at DESC LIMIT 20";
+$result = $mysqli->query($query);
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="css/style.css">
+<title>تاجر - الإعلانات الحديثة</title>
+</head>
+<body>
+<header>آخر الإعلانات</header>
+<div class="cards">
+<?php while($ad = $result->fetch_assoc()): ?>
+<div class="card">
+<img src="uploads/<?=htmlspecialchars($ad['main_image'])?>" alt="">
+<h3><?=htmlspecialchars($ad['title'])?></h3>
+<p>السعر: <?=htmlspecialchars($ad['price'])?></p>
+<p>المدينة: <?=htmlspecialchars($ad['city'])?></p>
+<a href="ad_details.php?id=<?=$ad['id']?>">تفاصيل</a>
+</div>
+<?php endwhile; ?>
+</div>
+</body>
+</html>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,0 +1,17 @@
+function previewImages(input, previewContainer) {
+    previewContainer.innerHTML = '';
+    Array.from(input.files).forEach(file => {
+        const reader = new FileReader();
+        reader.onload = e => {
+            const img = document.createElement('img');
+            img.src = e.target.result;
+            img.style.height = '80px';
+            previewContainer.appendChild(img);
+        };
+        reader.readAsDataURL(file);
+    });
+}
+
+function confirmDelete() {
+    return confirm('Are you sure you want to delete this ad?');
+}

--- a/login.php
+++ b/login.php
@@ -1,0 +1,35 @@
+<?php
+require_once 'includes/functions.php';
+$error = '';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $phone = sanitizeInput($_POST['phone']);
+    $pass  = $_POST['password'];
+    $stmt = $mysqli->prepare("SELECT id,password,is_admin FROM users WHERE phone=?");
+    $stmt->bind_param('s',$phone);
+    $stmt->execute();
+    $user = $stmt->get_result()->fetch_assoc();
+    if($user && password_verify($pass,$user['password'])){
+        $_SESSION['user_id']=$user['id'];
+        $_SESSION['is_admin']=$user['is_admin'];
+        header('Location: profile.php'); exit;
+    } else {
+        $error = 'بيانات غير صحيحة';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>تسجيل الدخول</header>
+<form method="post">
+<p style="color:red;"><?=$error?></p>
+<input type="text" name="phone" placeholder="رقم الجوال" required>
+<input type="password" name="password" placeholder="كلمة المرور" required>
+<button type="submit">دخول</button>
+</form>
+</body>
+</html>

--- a/profile.php
+++ b/profile.php
@@ -1,0 +1,30 @@
+<?php
+require_once 'includes/functions.php';
+if(!isLoggedIn()) { header('Location: login.php'); exit; }
+$userId = $_SESSION['user_id'];
+$ads = $mysqli->query("SELECT a.*, c.name AS city FROM ads a JOIN cities c ON a.city_id=c.id WHERE a.user_id=$userId ORDER BY a.created_at DESC");
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="css/style.css">
+<script src="js/scripts.js"></script>
+</head>
+<body>
+<header>الملف الشخصي</header>
+<a href="add_ad.php">إضافة إعلان جديد</a>
+<div class="cards">
+<?php while($ad = $ads->fetch_assoc()): ?>
+<div class="card">
+<h3><?=htmlspecialchars($ad['title'])?></h3>
+<p>السعر: <?=htmlspecialchars($ad['price'])?></p>
+<p>المدينة: <?=htmlspecialchars($ad['city'])?></p>
+<a href="ad_details.php?id=<?=$ad['id']?>">عرض</a> |
+<a href="edit_ad.php?id=<?=$ad['id']?>">تعديل</a> |
+<a href="delete_ad.php?id=<?=$ad['id']?>" onclick="return confirmDelete();">حذف</a>
+</div>
+<?php endwhile; ?>
+</div>
+</body>
+</html>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,35 @@
+<?php
+require_once 'includes/functions.php';
+$error='';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $name = sanitizeInput($_POST['name']);
+    $phone = sanitizeInput($_POST['phone']);
+    $pass = password_hash($_POST['password'], PASSWORD_DEFAULT);
+    $exists = $mysqli->query("SELECT id FROM users WHERE phone='$phone'")->num_rows;
+    if($exists){
+        $error='الرقم مسجل مسبقا';
+    } else {
+        $stmt = $mysqli->prepare("INSERT INTO users (name,phone,password,is_admin) VALUES (?,?,?,0)");
+        $stmt->bind_param('sss',$name,$phone,$pass);
+        $stmt->execute();
+        header('Location: login.php'); exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>تسجيل جديد</header>
+<form method="post">
+<p style="color:red;"><?=$error?></p>
+<input type="text" name="name" placeholder="الاسم" required>
+<input type="text" name="phone" placeholder="رقم الجوال" required>
+<input type="password" name="password" placeholder="كلمة المرور" required>
+<button type="submit">تسجيل</button>
+</form>
+</body>
+</html>

--- a/sql/tager_db.sql
+++ b/sql/tager_db.sql
@@ -1,0 +1,71 @@
+CREATE DATABASE IF NOT EXISTS tager_db DEFAULT CHARACTER SET utf8mb4;
+USE tager_db;
+
+CREATE TABLE users (
+ id INT AUTO_INCREMENT PRIMARY KEY,
+ name VARCHAR(100) NOT NULL,
+ phone VARCHAR(20) NOT NULL UNIQUE,
+ password VARCHAR(255) NOT NULL,
+ is_admin TINYINT(1) DEFAULT 0
+);
+
+CREATE TABLE categories (
+ id INT AUTO_INCREMENT PRIMARY KEY,
+ name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE cities (
+ id INT AUTO_INCREMENT PRIMARY KEY,
+ name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE ads (
+ id INT AUTO_INCREMENT PRIMARY KEY,
+ user_id INT NOT NULL,
+ title VARCHAR(255) NOT NULL,
+ description TEXT NOT NULL,
+ price DECIMAL(10,2) NOT NULL,
+ city_id INT NOT NULL,
+ category_id INT NOT NULL,
+ created_at DATETIME NOT NULL,
+ FOREIGN KEY (user_id) REFERENCES users(id),
+ FOREIGN KEY (city_id) REFERENCES cities(id),
+ FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+
+CREATE TABLE ad_images (
+ id INT AUTO_INCREMENT PRIMARY KEY,
+ ad_id INT NOT NULL,
+ image_path VARCHAR(255) NOT NULL,
+ FOREIGN KEY (ad_id) REFERENCES ads(id)
+);
+
+CREATE TABLE reports (
+ id INT AUTO_INCREMENT PRIMARY KEY,
+ ad_id INT NOT NULL,
+ user_id INT NOT NULL,
+ reason TEXT,
+ created_at DATETIME NOT NULL,
+ FOREIGN KEY (ad_id) REFERENCES ads(id),
+ FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE featured_ads (
+ id INT AUTO_INCREMENT PRIMARY KEY,
+ ad_id INT NOT NULL,
+ created_at DATETIME NOT NULL,
+ FOREIGN KEY (ad_id) REFERENCES ads(id)
+);
+
+INSERT INTO cities (name) VALUES ('الرياض'),('جدة'),('الدمام'),('مكة');
+INSERT INTO categories (name) VALUES ('سيارات'),('عقارات'),('إلكترونيات'),('أثاث');
+INSERT INTO users (name,phone,password,is_admin) VALUES
+ ('أحمد','0500000001',PASSWORD('1234'),1),
+ ('محمد','0500000002',PASSWORD('1234'),0),
+ ('سارة','0500000003',PASSWORD('1234'),0);
+INSERT INTO ads (user_id,title,description,price,city_id,category_id,created_at) VALUES
+ (1,'سيارة تويوتا','حالة ممتازة','30000',1,1,NOW()),
+ (2,'شقة للبيع','شقة كبيرة','500000',2,2,NOW()),
+ (3,'جوال جديد','أحدث إصدار','3000',3,3,NOW());
+INSERT INTO ad_images (ad_id,image_path) VALUES
+ (1,'car.jpg'),(2,'flat.jpg'),(3,'phone.jpg');


### PR DESCRIPTION
## Summary
- add database connection and helper functions
- implement basic pages for listing, adding, filtering and viewing ads
- add simple admin dashboard and ad management
- provide CSS/JS assets and SQL schema with seed data
- add `.gitignore` for uploads

## Testing
- `php -l includes/functions.php`
- `php -l index.php`
- `php -l add_ad.php`
- `php -l ad_details.php`
- `php -l ads.php`
- `php -l profile.php`
- `php -l login.php`
- `php -l register.php`
- `php -l admin/dashboard.php`
- `php -l admin/manage_ads.php`


------
https://chatgpt.com/codex/tasks/task_e_6889a9841418832bb930bdc9f451ddf7