### PR TITLE
Add category support and category-based browsing

### DIFF
--- a/add_ad.php
+++ b/add_ad.php
@@ -7,13 +7,16 @@ if (!is_logged_in()) {
     exit;
 }
 
+$categories = get_categories();
+
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title = sanitize($_POST['title'] ?? '');
     $desc  = sanitize($_POST['description'] ?? '');
     $price = sanitize($_POST['price'] ?? '');
-    if ($title && $desc && $price !== '') {
-        if (add_ad($title, $desc, $price)) {
+    $category_id = (int)($_POST['category_id'] ?? 0);
+    if ($title && $desc && $price !== '' && $category_id) {
+        if (add_ad($title, $desc, $price, $category_id)) {
             header('Location: ads.php');
             exit;
         } else {
@@ -37,6 +40,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <p style="color:red;"><?php echo $error; ?></p>
     <?php endif; ?>
     <form method="post">
+        <label>Category:
+            <select name="category_id">
+                <option value="">Select category</option>
+                <?php foreach ($categories as $cat): ?>
+                    <option value="<?php echo $cat['id']; ?>"><?php echo htmlspecialchars($cat['name']); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </label><br>
         <label>Title: <input type="text" name="title"></label><br>
         <label>Description:<br><textarea name="description"></textarea></label><br>
         <label>Price: <input type="text" name="price"></label><br>

--- a/ads.php
+++ b/ads.php
@@ -2,7 +2,9 @@
 session_start();
 require_once 'includes/functions.php';
 
-$ads = get_ads();
+$category_id = (int)($_GET['category'] ?? 0);
+$category = $category_id ? get_category($category_id) : null;
+$ads = get_ads($category_id ?: null);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -12,7 +14,7 @@ $ads = get_ads();
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <h1>Ads</h1>
+    <h1>Ads<?php echo $category ? ' - ' . htmlspecialchars($category['name']) : ''; ?></h1>
     <ul>
     <?php foreach ($ads as $ad): ?>
         <li><a href="ad_details.php?id=<?php echo $ad['id']; ?>"><?php echo htmlspecialchars($ad['title']); ?></a></li>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -34,21 +34,45 @@ function logout(): void {
     session_destroy();
 }
 
-function add_ad(string $title, string $description, string $price): bool {
+function add_ad(string $title, string $description, string $price, int $category_id): bool {
     $pdo = get_db_connection();
-    $stmt = $pdo->prepare('INSERT INTO ads (user_id, title, description, price) VALUES (?, ?, ?, ?)');
-    return $stmt->execute([$_SESSION['user_id'], $title, $description, $price]);
+    $stmt = $pdo->prepare('INSERT INTO ads (user_id, category_id, title, description, price) VALUES (?, ?, ?, ?, ?)');
+    return $stmt->execute([
+        $_SESSION['user_id'],
+        $category_id,
+        $title,
+        $description,
+        $price
+    ]);
 }
 
-function get_ads(): array {
+function get_ads(?int $category_id = null): array {
     $pdo = get_db_connection();
-    $stmt = $pdo->query('SELECT * FROM ads ORDER BY created_at DESC');
+    if ($category_id) {
+        $stmt = $pdo->prepare('SELECT * FROM ads WHERE category_id = ? ORDER BY created_at DESC');
+        $stmt->execute([$category_id]);
+    } else {
+        $stmt = $pdo->query('SELECT * FROM ads ORDER BY created_at DESC');
+    }
     return $stmt->fetchAll();
 }
 
 function get_ad(int $id) {
     $pdo = get_db_connection();
     $stmt = $pdo->prepare('SELECT * FROM ads WHERE id = ?');
+    $stmt->execute([$id]);
+    return $stmt->fetch();
+}
+
+function get_categories(): array {
+    $pdo = get_db_connection();
+    $stmt = $pdo->query('SELECT * FROM categories ORDER BY name');
+    return $stmt->fetchAll();
+}
+
+function get_category(int $id) {
+    $pdo = get_db_connection();
+    $stmt = $pdo->prepare('SELECT * FROM categories WHERE id = ?');
     $stmt->execute([$id]);
     return $stmt->fetch();
 }

--- a/index.php
+++ b/index.php
@@ -2,6 +2,7 @@
 session_start();
 require_once 'includes/functions.php';
 
+$categories = get_categories();
 $ads = get_ads();
 ?>
 <!DOCTYPE html>
@@ -21,6 +22,13 @@ $ads = get_ads();
     <?php else: ?>
         <p><a href="login.php">Login</a> | <a href="register.php">Register</a></p>
     <?php endif; ?>
+
+    <h2>Categories</h2>
+    <ul>
+    <?php foreach ($categories as $cat): ?>
+        <li><a href="ads.php?category=<?php echo $cat['id']; ?>"><?php echo htmlspecialchars($cat['name']); ?></a></li>
+    <?php endforeach; ?>
+    </ul>
 
     <h2>Latest Ads</h2>
     <ul>


### PR DESCRIPTION
## Summary
- Fetch categories from database and expose helper functions for category lookup
- List categories on the home page and allow ads to be filtered by category
- Include category selection when posting ads

## Testing
- `php -l index.php`
- `php -l ads.php`
- `php -l add_ad.php`
- `php -l includes/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_688acad034b0832bacc3a4f38c4cbb7f